### PR TITLE
feat: Add Markdown Support for Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ Follow the instructions to open the development tools
     flutter run
     ```
 
+## Markdown Support
+
+Stealthnote Mobile supports a variety of Markdown features for rich text formatting in your notes. You can use common Markdown syntax to create headers, lists, bold and italic text, links, and more.
+
+Below is an example of how Markdown is rendered in the app:
+
+<p align="center">
+ <a href="https://i.imgur.com/vcfzPmT.png"><img src="https://i.imgur.com/vcfzPmT.png" alt="Markdown Example" width="300"/></a>
+    <br>
+    <em>Stealthnote Mobile Support Markdown</em>
+</p>
+
 ## 📊 Benchmarks
 
 The following benchmarks were conducted on iPhone and Android in release mode:

--- a/flutter/lib/screens/message_card.dart
+++ b/flutter/lib/screens/message_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:mopro_flutter/mopro_flutter.dart';
 import 'package:mopro_flutter/mopro_flutter_platform_interface.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 
 import '../services/fetch_messages.dart';
 import '../services/fetch_googleJWTpubKey.dart';
@@ -178,7 +179,7 @@ class _MessageCardState extends State<MessageCard> {
               ],
             ),
             const SizedBox(height: 12),
-            Text(widget.msg.body),
+            MarkdownBody(data: widget.msg.body),
             const SizedBox(height: 8),
             Row(
               children: [

--- a/flutter/lib/screens/signin_card.dart
+++ b/flutter/lib/screens/signin_card.dart
@@ -7,6 +7,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:mopro_flutter/mopro_flutter.dart';
 import 'package:mopro_flutter/mopro_flutter_platform_interface.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:markdown_editor_plus/markdown_editor_plus.dart';
 import '../firebase_options.dart';
 import '../services/auth_service.dart';
 import '../services/create_membershipt.dart';
@@ -33,6 +34,11 @@ class _SignInCardState extends State<SignInCard> {
   final moproFlutterPlugin = MoproFlutter();
   bool _isLoading = false;
   final TextEditingController _textController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+  }
 
   @override
   void dispose() {
@@ -146,10 +152,11 @@ class _SignInCardState extends State<SignInCard> {
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
-            TextField(
+            MarkdownAutoPreview(
               controller: _textController,
+              emojiConvert: true,
               decoration: InputDecoration(
-                hintText: 'What\'s happening at your company?',
+                hintText: "What's happening at your company?",
                 border: InputBorder.none,
                 contentPadding: EdgeInsets.zero,
               ),

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
   http: ^1.3.0
   flutter_secure_storage: ^9.2.4
   flutter_web_auth_2: ^4.1.0
+  flutter_markdown: ^0.7.1
+  markdown_editor_plus: ^0.2.15
 
 dev_dependencies:
   integration_test:


### PR DESCRIPTION
- Integrates `flutter_markdown` to render existing messages with Markdown formatting.
- Implements `markdown_editor_plus` for a WYSIWYG-like experience when composing new messages, providing an instant preview.

<table>
  <tr>
    <td align="center">
      <a href="https://i.imgur.com/vcfzPmT.png" target="_blank" rel="noopener noreferrer">
        <img src="https://i.imgur.com/vcfzPmT.png" alt="Stealthnote Mobile Markdown Example" width="300"/>
      </a>
      <br />
      <sub><b>iOS</b></sub>
    </td>
    <td align="center">
      <a href="https://github.com/user-attachments/assets/ad7b93fa-0b8a-4923-a4a2-060dd4ecee0b" target="_blank" rel="noopener noreferrer">
        <img src="https://github.com/user-attachments/assets/ad7b93fa-0b8a-4923-a4a2-060dd4ecee0b" alt="Stealthnote Web Example" width="300"/>
      </a>
      <br />
      <sub><b>Android</b></sub>
    </td>
  </tr>
</table>