### PR TITLE
Fix/ios bindings

### DIFF
--- a/flutter/ios/Podfile.lock
+++ b/flutter/ios/Podfile.lock
@@ -9,37 +9,37 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - Firebase/Auth (11.10.0):
+  - Firebase/Auth (11.15.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 11.10.0)
-  - Firebase/CoreOnly (11.10.0):
-    - FirebaseCore (~> 11.10.0)
-  - firebase_auth (5.5.3):
-    - Firebase/Auth (= 11.10.0)
+    - FirebaseAuth (~> 11.15.0)
+  - Firebase/CoreOnly (11.15.0):
+    - FirebaseCore (~> 11.15.0)
+  - firebase_auth (5.6.1):
+    - Firebase/Auth (= 11.15.0)
     - firebase_core
     - Flutter
-  - firebase_core (3.13.0):
-    - Firebase/CoreOnly (= 11.10.0)
+  - firebase_core (3.15.0):
+    - Firebase/CoreOnly (= 11.15.0)
     - Flutter
-  - FirebaseAppCheckInterop (11.11.0)
-  - FirebaseAuth (11.10.0):
+  - FirebaseAppCheckInterop (11.15.0)
+  - FirebaseAuth (11.15.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.10.0)
-    - FirebaseCoreExtension (~> 11.10.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
-    - GoogleUtilities/Environment (~> 8.0)
+    - FirebaseCore (~> 11.15.0)
+    - FirebaseCoreExtension (~> 11.15.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/Environment (~> 8.1)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
     - RecaptchaInterop (~> 101.0)
-  - FirebaseAuthInterop (11.11.0)
-  - FirebaseCore (11.10.0):
-    - FirebaseCoreInternal (~> 11.10.0)
-    - GoogleUtilities/Environment (~> 8.0)
-    - GoogleUtilities/Logger (~> 8.0)
-  - FirebaseCoreExtension (11.10.0):
-    - FirebaseCore (~> 11.10.0)
-  - FirebaseCoreInternal (11.10.0):
-    - "GoogleUtilities/NSData+zlib (~> 8.0)"
+  - FirebaseAuthInterop (11.15.0)
+  - FirebaseCore (11.15.0):
+    - FirebaseCoreInternal (~> 11.15.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Logger (~> 8.1)
+  - FirebaseCoreExtension (11.15.0):
+    - FirebaseCore (~> 11.15.0)
+  - FirebaseCoreInternal (11.15.0):
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
   - Flutter (1.0.0)
   - flutter_secure_storage (6.0.0):
     - Flutter
@@ -56,28 +56,28 @@ PODS:
     - AppCheckCore (~> 11.0)
     - GTMAppAuth (< 5.0, >= 4.1.1)
     - GTMSessionFetcher/Core (~> 3.3)
-  - GoogleUtilities/AppDelegateSwizzler (8.0.2):
+  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (8.0.2):
+  - GoogleUtilities/Environment (8.1.0):
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.0.2):
+  - GoogleUtilities/Logger (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (8.0.2):
+  - GoogleUtilities/Network (8.1.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (8.0.2)":
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.0.2)
-  - GoogleUtilities/Reachability (8.0.2):
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/Reachability (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (8.0.2):
+  - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - GTMAppAuth (4.1.1):
@@ -155,29 +155,29 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  Firebase: 1fe1c0a7d9aaea32efe01fbea5f0ebd8d70e53a2
-  firebase_auth: 83bf106e5ac670dd3a0af27a86be6cba16a85723
-  firebase_core: 2d4534e7b489907dcede540c835b48981d890943
-  FirebaseAppCheckInterop: f23709c9ce92d810aa53ff4ce12ad3e666a3c7be
-  FirebaseAuth: c4146bdfdc87329f9962babd24dae89373f49a32
-  FirebaseAuthInterop: ac22ed402c2f4e3a8c63ebd3278af9a06073c1be
-  FirebaseCore: 8344daef5e2661eb004b177488d6f9f0f24251b7
-  FirebaseCoreExtension: 6f357679327f3614e995dc7cf3f2d600bdc774ac
-  FirebaseCoreInternal: ef4505d2afb1d0ebbc33162cb3795382904b5679
+  Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e
+  firebase_auth: a9d4b86c7d96167b14c044262cc7cf58c6e59d8a
+  firebase_core: d4cf851433d9aa90e6071aea763460566c02db16
+  FirebaseAppCheckInterop: 06fe5a3799278ae4667e6c432edd86b1030fa3df
+  FirebaseAuth: a6575e5fbf46b046c58dc211a28a5fbdd8d4c83b
+  FirebaseAuthInterop: 7087d7a4ee4bc4de019b2d0c240974ed5d89e2fd
+  FirebaseCore: efb3893e5b94f32b86e331e3bd6dadf18b66568e
+  FirebaseCoreExtension: edbd30474b5ccf04e5f001470bdf6ea616af2435
+  FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  flutter_web_auth_2: 5c8d9dcd7848b5a9efb086d24e7a9adcae979c80
-  google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
+  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  flutter_web_auth_2: 06d500582775790a0d4c323222fcb6d7990f9603
+  google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
-  GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  mopro_flutter: 584c5d3c09b680eec2c24ddf496ee4b4d5ba7083
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  mopro_flutter: 3ed6a1573374500ce41d440d5dcc5818af91d757
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: a57f30d18f102dd3ce366b1d62a55ecbef2158e5
 

--- a/flutter/ios/Podfile.lock
+++ b/flutter/ios/Podfile.lock
@@ -173,7 +173,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  mopro_flutter: 3ed6a1573374500ce41d440d5dcc5818af91d757
+  mopro_flutter: 1ab995bc9e2f1a8c179cbafb8d8459849335251b
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba

--- a/flutter/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/flutter/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -54,6 +55,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/flutter/mopro_flutter_plugin/ios/mopro_flutter.podspec
+++ b/flutter/mopro_flutter_plugin/ios/mopro_flutter.podspec
@@ -2,6 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint mopro_flutter.podspec` to validate before publishing.
 #
+
 Pod::Spec.new do |s|
   s.name             = 'mopro_flutter'
   s.version          = '0.0.1'
@@ -20,7 +21,79 @@ A new Flutter plugin project.
   s.dependency 'Flutter'
   s.platform = :ios, '11.0'
 
-  # Flutter.framework does not contain a i386 slice.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  # Dynamically determine which architectures to exclude based on xcframework availability
+  xcframework_path = File.join(File.dirname(__FILE__), 'MoproiOSBindings', 'MoproBindings.xcframework')
+  info_plist_path = File.join(xcframework_path, 'Info.plist')
+  
+  excluded_config = {}
+  
+  if File.exist?(info_plist_path)
+    begin
+      content = File.read(info_plist_path)
+      simulator_archs = []
+      device_archs = []
+      
+      # Simple XML parsing to extract architectures
+      current_lib = nil
+      in_supported_archs = false
+      is_simulator = false
+      
+      content.each_line do |line|
+        line = line.strip
+        
+        # Detect library blocks
+        if line.include?('<key>LibraryIdentifier</key>')
+          current_lib = :new_lib
+          is_simulator = false
+        elsif current_lib == :new_lib && line.include?('<string>') && line.include?('simulator')
+          is_simulator = true
+        elsif line.include?('<key>SupportedArchitectures</key>')
+          in_supported_archs = true
+        elsif in_supported_archs && line.include?('</array>')
+          in_supported_archs = false
+          current_lib = nil
+        elsif in_supported_archs && line.include?('<string>') && line.include?('</string>')
+          # Extract architecture name
+          arch = line.gsub(/<\/?string>/, '').strip
+          if is_simulator
+            simulator_archs << arch
+          else
+            device_archs << arch
+          end
+        end
+      end
+      
+      # All possible architectures
+      all_simulator_archs = ['x86_64', 'arm64']
+      all_device_archs = ['arm64', 'armv7']
+      
+      # Exclude unsupported simulator architectures
+      excluded_simulator = all_simulator_archs - simulator_archs.uniq
+      if !excluded_simulator.empty?
+        excluded_config['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = excluded_simulator.join(' ')
+      end
+      
+      # Exclude unsupported device architectures  
+      excluded_device = all_device_archs - device_archs.uniq
+      if !excluded_device.empty?
+        excluded_config['EXCLUDED_ARCHS[sdk=iphoneos*]'] = excluded_device.join(' ')
+      end
+      
+    rescue => e
+      puts "Warning: Could not parse xcframework Info.plist: #{e.message}"
+      # Fallback to safe defaults - exclude x86_64 only if we can't parse
+      excluded_config['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'x86_64'
+    end
+  else
+    puts "Warning: xcframework Info.plist not found, using safe defaults"
+    # Fallback to safe defaults
+    excluded_config['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'x86_64'
+  end
+  
+  # Build the pod_target_xcconfig with dynamic exclusions
+  base_config = { 'DEFINES_MODULE' => 'YES' }
+  final_config = base_config.merge(excluded_config)
+
+  s.pod_target_xcconfig = final_config
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
related issue
- #16 
this error occurs when the user only builds the ARM iOS-simulator architecture, but the podspec targets both ARM and x86 simulators, so it cannot fetch the moproFFI module.

this PR introduces
- updating outdated dependencies like Firebase
- dynamically exclude unsupported architectures in podspec